### PR TITLE
Fix Mute/Unmute problem

### DIFF
--- a/variod.c
+++ b/variod.c
@@ -132,6 +132,8 @@ int create_xcsoar_connection()
 	wait_for_XCSoar(xcsoar_sock, (struct sockaddr*)&s_xcsoar);
 	// make socket to XCsoar non-blocking
 	fcntl(xcsoar_sock, F_SETFL, O_NONBLOCK);
+	//enable vario sound
+	vario_unmute();
 	return xcsoar_sock;
 
 }
@@ -283,8 +285,7 @@ int main(int argc, char *argv[])
 
 		// Socket is connected
 
-		//enable vario sound
-		vario_unmute();
+		
 		// get current values for Polar, MC, ... from XCSoar
 		// since we might have started after XCSoar was running for a while
 		request_current_settings = true;


### PR DESCRIPTION
Moved the enabling of the vario sound to the connection function.
It only enables sound on connect or reconnect.
Before the change sound was unmuted constantly. It was inside While(1) infinite loop.
Please test before merging. Works in my OV 5,7.