### PR TITLE
addressing issues listed in #20

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 #Some compiler stuff and flags
 CFLAGS += -g -Wall -fpermissive
 EXECUTABLE = variod
-_OBJ = audiovario.o variod.o cmdline_parser.o configfile_parser.o nmea_parser.o stf.o utils.o
+_OBJ = audiovario.o variod.o cmdline_parser.o configfile_parser.o nmea_parser.o stf.o utils.o nmea_checksum.o
 OBJ = $(patsubst %,$(ODIR)/%,$(_OBJ))
 OBJ_CAL = $(patsubst %,$(ODIR)/%,$(_OBJ_CAL))
 LIBS = -lpulse -lm -lpthread

--- a/nmea_checksum.c
+++ b/nmea_checksum.c
@@ -1,0 +1,60 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#include "nmea_checksum.h"
+
+#include <cassert>
+#include <cstring>
+#include <cstdlib>
+#include <cstdio>
+#include <cstdint>
+
+bool
+verify_nmea_checksum(const char *p)
+{
+	assert(p != NULL);
+
+	const char *asterisk = strrchr(p, '*');
+	if (asterisk == NULL)
+		return false;
+
+	const char *checksum_string = asterisk + 1;
+	char *endptr;
+	unsigned long read_checsum2 = strtoul(checksum_string, &endptr, 16);
+	if (endptr == checksum_string || *endptr != 0 || read_checsum2 >= 0x100)
+		return false;
+
+	uint8_t read_checsum = (unsigned char)read_checsum2;
+	uint8_t calc_checksum = nmea_checksum(p, asterisk - p);
+
+	return calc_checksum == read_checsum;
+}
+
+void
+append_nmea_checksum(char *p)
+{
+	assert(p != NULL);
+
+	sprintf(p + strlen(p), "*%02X", nmea_checksum(p));
+}
+

--- a/nmea_checksum.h
+++ b/nmea_checksum.h
@@ -1,0 +1,107 @@
+/*
+Copyright_License {
+
+  XCSoar Glide Computer - http://www.xcsoar.org/
+  Copyright (C) 2000-2016 The XCSoar Project
+  A detailed list of copyright holders can be found in the file "AUTHORS".
+
+  This program is free software; you can redistribute it and/or
+  modify it under the terms of the GNU General Public License
+  as published by the Free Software Foundation; either version 2
+  of the License, or (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program; if not, write to the Free Software
+  Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+}
+*/
+
+#ifndef VARIOD_NMEA_CHECKSUM_H
+#define VARIOD_NMEA_CHECKSUM_H
+
+#include <cstdint>
+#include <cstring>
+
+/**
+ * Calculates the checksum for the specified line (without the
+ * asterisk and the newline character).
+ *
+ * @param p a NULL terminated string
+ */
+static inline uint8_t
+nmea_checksum(const char *p)
+{
+	uint8_t checksum = 0;
+
+	/* skip the dollar sign at the beginning (the exclamation mark is
+	   used by CAI302 */
+	if (*p == '$' || *p == '!')
+		++p;
+
+	while (*p != 0)
+		checksum ^= *p++;
+
+	return checksum;
+}
+
+/**
+ * Chops off the checksum part of the sentence
+ * That is the part including and after the asterisk
+ *
+ * @param p a NULL terminated string
+ */
+static inline void
+nmea_chop_checksum(char *p)
+{
+	char *asterisk;
+
+	if ((asterisk = strchr(p,'*')) != NULL) *asterisk = '\0';
+}
+
+/**
+ * Calculates the checksum for the specified line (without the
+ * asterisk and the newline character).
+ *
+ * @param p a string
+ * @param length the number of characters in the string
+ */
+static inline uint8_t
+nmea_checksum(const char *p, unsigned length)
+{
+	uint8_t checksum = 0;
+
+	unsigned i = 0;
+
+	/* skip the dollar sign at the beginning (the exclamation mark is
+	   used by CAI302 */
+	if (length > 0 && (*p == '$' || *p == '!')) {
+		++i;
+		++p;
+	}
+
+	for (; i < length; ++i)
+		checksum ^= *p++;
+
+	return checksum;
+}
+
+/**
+ * Verify the NMEA checksum at the end of the specified string,
+ * separated with an asterisk ('*').
+ */
+bool
+verify_nmea_checksum(const char *p);
+
+/**
+ * Caclulates the checksum of the specified string, and appends it at
+ * the end, preceded by an asterisk ('*').
+ */
+void
+append_nmea_checksum(char *p);
+
+#endif // VARIOD_NMEA_CHECKSUM_H

--- a/nmea_parser.c
+++ b/nmea_parser.c
@@ -14,8 +14,6 @@ void parse_NMEA_sensor(char* message, t_sensor_context* sensors)
 	// https://en.wikipedia.org/wiki/NMEA_0183#Message_structure
 	// Exception to this: sentence must be terminated with '\0', no '\n', or '\r' allowed.
 
-	char *val;
-	char *endptr;
 	static char buffer[100]; // NMEA sentence must not be longer than 82 chars
 	const char delimiter[]=",*";
 	char *ptr=NULL;
@@ -39,9 +37,10 @@ void parse_NMEA_sensor(char* message, t_sensor_context* sensors)
 	else ptr = NULL;
 
 	while (ptr != NULL) {
-		val = strtok(NULL, delimiter);
+		char *val = strtok(NULL, delimiter);
 		if (val == NULL) return; // there is no value after the qualifier
 
+		char *endptr;
 		float fv = strtof(val,&endptr);
 		if (endptr == val || *endptr != 0) return; // not a clean number
 

--- a/nmea_parser.c
+++ b/nmea_parser.c
@@ -16,7 +16,6 @@ void parse_NMEA_sensor(char* message, t_sensor_context* sensors)
 
 	char *val;
 	char *endptr;
-	float fv;
 	static char buffer[100]; // NMEA sentence must not be longer than 82 chars
 	const char delimiter[]=",*";
 	char *ptr=NULL;
@@ -43,7 +42,7 @@ void parse_NMEA_sensor(char* message, t_sensor_context* sensors)
 		val = strtok(NULL, delimiter);
 		if (val == NULL) return; // there is no value after the qualifier
 
-		fv = strtof(val,&endptr);
+		float fv = strtof(val,&endptr);
 		if (endptr == val || *endptr != 0) return; // not a clean number
 
 		if (strcmp(ptr,"E") == 0) {

--- a/variod.c
+++ b/variod.c
@@ -178,7 +178,6 @@ int main(int argc, char *argv[])
 	char buff[100]; // NMEA sentences must not be longer than 82 bytes
 	char client_message[2001];
 	char *sentence;
-	int sensor_sentence_counter = 0;
 	int nFlags;
 	t_sensor_context sensors;
 	t_polar polar;
@@ -332,7 +331,7 @@ int main(int argc, char *argv[])
 		//enable vario sound
 		vario_unmute();	
 		
-		sensor_sentence_counter = 0;
+		int sensor_sentence_counter = 0;
 		//Receive a message from sensord and forward to XCsoar
 		while ((read_size = recv(connfd , client_message , sizeof(client_message)-1, 0 )) > 0 )
 		{


### PR DESCRIPTION
It improves robustness of NMEA parsers.
It presents one NMEA sentence at a time to be parsed.
It follows the guidelines for NMEA sentence structure given here:
https://en.wikipedia.org/wiki/NMEA_0183#Message_structure
with listed exeptions:
NMEA sentences are only valid if they have a checksum.
The <CR><LF> at the end of the sentence is not enforced.
One of the 2 is sufficient, but not less than 1 is required.

The next steps:
Implement the request to XCSoar to send current settings.
Handle incomplete senteces from recv().
Both are marked in the code as TODO: