### PR TITLE
Changed $RPO sentence parsing strategy. Fixes #46

### DIFF
--- a/nmea_parser.c
+++ b/nmea_parser.c
@@ -248,7 +248,7 @@ void parse_NMEA_command(char* message, int xcsoar_sock)
 									case 'R':
 										//Set Real Polar
 										if (*(ptr2+1) == 'P' &&  *(ptr2+2) == 'O') {
-											if (read_float_from_sentence(3,fvals,ptr2+4,del2)) {
+											if (read_float_from_sentence(3,fvals,ptr2+4)) {
 												// convert horizontal speed from m/s to km/h
 												status&=(0x02^0xff);
 											  	polar.a=fvals[0]/(3.6*3.6);

--- a/utils.c
+++ b/utils.c
@@ -22,20 +22,24 @@
 #include <string.h>
 
 
-// see if we get all requested parameter(s) before we start setting them
+// copies n floats to fv[]
 bool read_float_from_sentence(int n,float fv[],char *str,const char *delim)
 {
-	char *vp;
-	char *endptr;
-
+	char *comma;
 	if (n > NUM_FV) return false;
 
 	for (int i=0; i < n; i++) {
-		vp = strtok(str,delim);
-		if (vp == NULL) return false;
-
-		fv[i] = strtof(vp,&endptr);
-		if (endptr == vp || *endptr != 0) return false;
+		if (i!=n-1){
+			fv[i] = strtof(str,&comma);
+			str=comma;
+			++str;
+		}
+		else{
+			fv[i] = strtof(str,NULL);
+		}
+		if(fv[i]==0.0f){
+			return false;
+		}
 	}
 	return true;
 }

--- a/utils.c
+++ b/utils.c
@@ -23,7 +23,7 @@
 
 
 // copies n floats to fv[]
-bool read_float_from_sentence(int n,float fv[],char *str,const char *delim)
+bool read_float_from_sentence(int n,float fv[],char *str)
 {
 	char *comma;
 	if (n > NUM_FV) return false;

--- a/utils.h
+++ b/utils.h
@@ -38,4 +38,4 @@
  * delim string of chars representing the limiters between values in the sentence.
  * return true on success or false if any of the checks fail
  ******************************************/
-bool read_float_from_sentence(int n,float fv[],char *str,const char *delim);
+bool read_float_from_sentence(int n,float fv[],char *str);


### PR DESCRIPTION
Parser filled the three vector positions for polar coefficients a,b and c with the first value received in the NMEA sentence.
Changed parsing strategy from strtok() to using strtof().